### PR TITLE
Fix unexpected attribute for PS4 Machine

### DIFF
--- a/ProvisionPullClient.ps1
+++ b/ProvisionPullClient.ps1
@@ -44,11 +44,11 @@ Switch ($PSVersionTable.PSVersion.Major)
 {
     5 {
          Invoke-WebRequest https://raw.githubusercontent.com/justeat/PowerShellDSCUtils/master/Version5DSC.ps1 -OutFile "$PSScriptRoot\DSC\Version5DSC.ps1"
-        . $PSScriptRoot\Version5DSC.ps1 -ConfigurationIDGUID $ConfigurationIDGUID -PullServerUrl $PullServerURL
+        . $PSScriptRoot\DSC\Version5DSC.ps1 -ConfigurationIDGUID $ConfigurationIDGUID -PullServerUrl $PullServerURL
     }
     4 {
         Invoke-WebRequest https://raw.githubusercontent.com/justeat/PowerShellDSCUtils/master/Version4DSC.ps1 -OutFile "$PSScriptRoot\DSC\Version4DSC.ps1"
-        . $PSScriptRoot\Version4DSC.ps1 -ConfigurationIDGUID $ConfigurationIDGUID -PullServerUrl $PullServerURL
+        . $PSScriptRoot\DSC\Version4DSC.ps1 -ConfigurationIDGUID $ConfigurationIDGUID -PullServerUrl $PullServerURL
     }
     # Graceful exit if PS Version doesnt mach above
     default { exit }

--- a/ProvisionPullClient.ps1
+++ b/ProvisionPullClient.ps1
@@ -1,15 +1,4 @@
-﻿[cmdletbinding()]
-Param (
-    # Parameter that defines the configuration ID to be used by the client
-    [Parameter(Mandatory=$True)]
-    [string]$ConfigurationIDGUID,
-
-    # Parameter that defines the Pull server the client will use
-    [Parameter(Mandatory=$True)]
-    [string]$PullServerURL
-)
-
-<#
+﻿<#
 .SYNOPSIS
     Configures a machine to be a pull client in a DSC environment
 
@@ -27,6 +16,17 @@ Param (
 
     ProvisionPullClient.ps1 e7d38156-02b2-42d3-ad0a-4457fe8cf380 https://pullserver.example.com:8080/PSDSCPullServer.svc
 #>
+
+[cmdletbinding()]
+Param (
+    # Parameter that defines the configuration ID to be used by the client
+    [Parameter(Mandatory=$True)]
+    [string]$ConfigurationIDGUID,
+
+    # Parameter that defines the Pull server the client will use
+    [Parameter(Mandatory=$True)]
+    [string]$PullServerURL
+)
 
 
 # Temp folder used for outputting the MOF files so they are in a known location

--- a/Version4DSC.ps1
+++ b/Version4DSC.ps1
@@ -10,7 +10,7 @@ Param (
     [string]$PullServerURL
 )
 
-Set-Location "$PSScriptRoot\DSC"
+Set-Location "$PSScriptRoot"
 
 Configuration SimpleMetaConfigurationForPull 
 { 

--- a/Version4DSC.ps1
+++ b/Version4DSC.ps1
@@ -1,0 +1,31 @@
+﻿[cmdletbinding()]
+
+Param (
+    # Parameter that defines the configuration ID to be used by the client
+    [Parameter(Mandatory=$True)]
+    [string]$ConfigurationIDGUID,
+
+    # Parameter that defines the Pull server the client will use
+    [Parameter(Mandatory=$True)]
+    [string]$PullServerURL
+)
+
+Set-Location "$PSScriptRoot\DSC"
+
+Configuration SimpleMetaConfigurationForPull 
+{ 
+    LocalConfigurationManager 
+    { 
+        ConfigurationID = $ConfigurationIDGUID;
+        RefreshMode = "PULL";
+        DownloadManagerName = "WebDownloadManager";
+        RebootNodeIfNeeded = $true;
+        RefreshFrequencyMins = 30;
+        ConfigurationModeFrequencyMins = 30; 
+        ConfigurationMode = "ApplyAndAutoCorrect";
+        DownloadManagerCustomData = @{ServerUrl = "$PullServerURL"; AllowUnsecureConnection = “FALSE”}
+    } 
+} 
+SimpleMetaConfigurationForPull -Output ".\."
+
+Set-DscLocalConfigurationManager -Path ".\."

--- a/Version5DSC.ps1
+++ b/Version5DSC.ps1
@@ -1,0 +1,37 @@
+﻿[cmdletbinding()]
+
+Param (
+    # Parameter that defines the configuration ID to be used by the client
+    [Parameter(Mandatory=$True)]
+    [string]$ConfigurationIDGUID,
+
+    # Parameter that defines the Pull server the client will use
+    [Parameter(Mandatory=$True)]
+    [string]$PullServerURL
+)
+
+Set-Location "$PSScriptRoot\DSC"
+
+[DSCLocalConfigurationManager()]
+    
+    configuration PullClientConfigID
+    {
+        Node localhost
+        {
+            Settings
+            {
+                RefreshMode = 'Pull'
+                ConfigurationID = $ConfigurationIDGUID
+                RefreshFrequencyMins = 30 
+                RebootNodeIfNeeded = $true
+                ConfigurationMode = "ApplyAndAutoCorrect"
+            }
+            ConfigurationRepositoryWeb PullSrv
+            {
+                ServerURL = $PullServerURL
+            }      
+        }
+    }
+    PullClientConfigID
+
+    Set-DscLocalConfigurationManager -Path ".\."

--- a/Version5DSC.ps1
+++ b/Version5DSC.ps1
@@ -10,7 +10,7 @@ Param (
     [string]$PullServerURL
 )
 
-Set-Location "$PSScriptRoot\DSC"
+Set-Location "$PSScriptRoot"
 
 [DSCLocalConfigurationManager()]
     
@@ -34,4 +34,4 @@ Set-Location "$PSScriptRoot\DSC"
     }
     PullClientConfigID
 
-    Set-DscLocalConfigurationManager -Path ".\."
+    Set-DscLocalConfigurationManager -Path ".\PullClientConfigID"


### PR DESCRIPTION
Inital push to handle issues when having PSv5 code in a script trying to be run on a device that only has psversion 4.

What I've done is split the script into three. One for determining the version and having the params passed. The second and third configure DSC, however one does for version 4 machines, one for version 5. 

@je-mandelbug FYI, please review. Runs without errors manually. We need to test config is actually on machine tomorrow. 
